### PR TITLE
Added support for read all iscc options

### DIFF
--- a/lib/iscc.js
+++ b/lib/iscc.js
@@ -18,6 +18,17 @@ module.exports = function(scriptPath, options, callback) {
 		if (options && options.signtoolname && options.signtoolcommand) {
 			args.push('/S' + options.signtoolname + '=' + options.signtoolcommand.replace(/['"]/g, '$q'));
 		}
+		
+		//reset pre-processed options
+		delete options.verbose;
+		delete options.signtoolname;
+		delete options.signtoolcommand;
+		
+		//cycle all other options and add it to args
+		Object.keys(options).forEach(function(key) {
+			var val = options[key];
+			args.push('/' + key + val);
+		});
 	}
 	
 	if (!/^win/.test(process.platform)) {


### PR DESCRIPTION
Hello,
I modified the iscc.js code, catching all iscc.exe options.
Now, all iscc options, so:

  /O(+|-)            Enable or disable output (overrides Output)
  /O<path>           Output files to specified path (overrides OutputDir)
  /F<filename>       Overrides OutputBaseFilename with the specified filename
  /S<name>=<command> Sets a SignTool with the specified name and command
  /Q                 Quiet compile (print error messages only)
  /Qp                Enable quiet compile while still displaying progress
  /D<name>[=<value>] Emulate #define public <name> <value>
  /$<letter>(+|-)    Emulate #pragma option -<letter>(+|-)
  /P<letter>(+|-)    Emulate #pragma parseroption -<letter>(+|-)
  /I<paths>          Emulate #pragma include <paths>
  /{#<string>        Emulate #pragma inlinestart <string>
  /}<string>         Emulate #pragma inlineend <string>
  /V<number>         Emulate #pragma verboselevel <number>

can be catched in innosetup-compiler, and used inside ISS script, simply these options need to be called with --<OPTION>=<VALUE> instead /OPTION<VALUE>

this iscc option:

/O./build/installer

can be called like:

--O=./build/installer

About /D option (Emulate #define public <name> <value>), you can join more than one option by adding ";", like:

--D=myvar1=myvalue1;myvar2=myvalue2

This is a little example:

innosetup-compiler mysetup.iss --O=./build/installer --D=myvar1=myvalue1;myvar2=myvalue2 --verbose


Inside .ISS file, myvar1 and myvar2 act as a define variable:  {#myvar1} 